### PR TITLE
Adds adjust method

### DIFF
--- a/.todo
+++ b/.todo
@@ -41,6 +41,7 @@
 ☐ Utils
   ☐ document units
   ✔ move hsl-rgb conversion functions to the HSL class
+☐ make units types? (for documentation purposes, might clarify some things)
 ☐ implement more methods
   ✔ get
     ✔ red
@@ -76,7 +77,7 @@
     ✔ transparentize
       ☐ fade-out (alias)
   ☐ edit (niche)
-    ☐ adjust-color
+    ✔ adjust-colors
     ☐ adjust-hue
     ☐ change-color
     ☐ complement

--- a/src/methods/adjust.ts
+++ b/src/methods/adjust.ts
@@ -1,0 +1,54 @@
+
+/* IMPORT */
+
+import Color from '../color';
+import HSL from '../color/hsl';
+import Utils from '../utils';
+
+/* ADJUST */
+
+function adjust ( color: string, options: { red?: number, green?: number, blue?: number, hue?: number, saturation?: number, lightness?: number, alpha?: number } ): string {
+
+  const { red, green, blue, hue, lightness, saturation, alpha } = options;
+
+  const optionsHasProperty = prop => options.hasOwnProperty ( prop );
+  if ( ( [ 'red', 'green', 'blue' ].some ( optionsHasProperty ) ) && ( [ 'hue', 'saturation', 'lightness' ].some ( optionsHasProperty ) ) ) {
+
+    throw new Error ( 'Cannot adjust an RGB property at the same time as an HSL property' )
+
+  }
+
+  [ red, green, blue ].forEach ( amount => amount && Utils.checkRange ( amount, -255, 255 ) );
+
+  [ lightness, saturation ].forEach ( amount => amount && Utils.checkRange ( amount, -100, 100 ) );
+
+  alpha && Utils.checkRange ( alpha, -1, 1 );
+
+  let rgba = Color.parse ( color );
+
+  if ( red ) rgba.r = Utils.clamp ( rgba.r + red, 0, 255 );
+  if ( green ) rgba.g = Utils.clamp ( rgba.g + green, 0, 255 );
+  if ( blue ) rgba.b = Utils.clamp ( rgba.b + blue, 0, 255 );
+
+  if ( hue || saturation || lightness ) {
+
+    const hsl = HSL.rgb2hsl ( rgba );
+  
+    if ( hue ) hsl.h = ( hsl.h + hue ) % 360;
+    if ( saturation ) hsl.s = Utils.clamp ( hsl.s + saturation, 0, 100 );
+    if ( lightness ) hsl.l = Utils.clamp ( hsl.l + lightness, 0, 100 );
+
+    
+    rgba = HSL.hsl2rgb ( hsl );
+
+  }
+
+  if ( alpha ) rgba.a = Utils.clamp ( rgba.a + alpha, 0, 1 );
+
+  return Color.output ( rgba );
+
+}
+
+/* EXPORT */
+
+export default adjust;

--- a/src/methods/index.ts
+++ b/src/methods/index.ts
@@ -19,6 +19,7 @@ import hsla from './hsla';
 import hsl from './hsla'; // alias
 import rgba from './rgba';
 import rgb from './rgba'; // alias
+import adjust from './adjust';
 
 /* EXPORT */
 
@@ -30,6 +31,7 @@ export {
   lighten,
   saturate,
   desaturate,
+  adjust,
   /* GET */
   alpha,
   opacity,

--- a/test/methods/adjust.js
+++ b/test/methods/adjust.js
@@ -1,0 +1,114 @@
+
+/* IMPORT */
+
+import {describe} from 'ava-spec';
+import {adjust} from '../../dist';
+import Color from '../../dist/color';
+import RGB from '../../dist/color/rgb';
+import HSL from '../../dist/color/hsl';
+;
+
+/* ADJUST */
+
+describe ( 'adjust', it => {
+
+  it ( 'adjusts RGB values', t => {
+
+    const tests = [
+      [ ['rgb(0, 0, 0)', { red: 100 }], 'rgb(100, 0, 0)' ],
+      [ ['rgb(0, 0, 0)', { green: 100 }], 'rgb(0, 100, 0)' ],
+      [ ['rgb(0, 0, 0)', { blue: 100 }], 'rgb(0, 0, 100)' ],
+      [ ['rgb(0, 0, 0)', { red: 100, green: 100 }], 'rgb(100, 100, 0)' ],
+      [ ['rgb(0, 0, 0)', { red: 100, green: 100, blue: 100 }], 'rgb(100, 100, 100)' ],
+      [ ['rgb(255, 255, 255)', { red: -100 }], 'rgb(155, 255, 255)' ],
+      [ ['rgb(255, 255, 255)', { green: -100 }], 'rgb(255, 155, 255)' ],
+      [ ['rgb(255, 255, 255)', { blue: -100 }], 'rgb(255, 255, 155)' ],
+      [ ['rgb(200, 0, 0)', { red: 100 }], 'rgb(255, 0, 0)' ],
+      [ ['rgb(100, 0, 0)', { red: -200 }], 'rgb(0, 0, 0)' ],
+    ];
+
+    tests.forEach ( ( [ args, result ] ) => {
+      t.is ( RGB.output ( Color.parse ( adjust ( ...args ) ) ), result );
+    });
+
+  });
+
+  it ( 'adjust HSL values', t => {
+
+    const tests = [
+      [ [ 'hsl(0, 50, 50)', { hue: 100 } ], 'hsl(100, 49.8, 50)' ],
+      [ [ 'hsl(0, 50, 50)', { saturation: 25 } ], 'hsl(0, 74.9, 50)' ],
+      [ [ 'hsl(0, 50, 50)', { lightness: 25 } ], 'hsl(0, 50, 74.9)' ],
+      [ [ 'hsl(0, 50, 50)', { hue: 100, saturation: 25  } ], 'hsl(100, 74.9, 50)' ],
+      [ [ 'hsl(0, 50, 50)', { hue: 100, saturation: 25, lightness: 25  } ], 'hsl(100, 75, 74.9)' ],
+      [ [ 'hsl(100, 50, 50)', { hue: -100 } ], 'hsl(0, 49.8, 50)' ],
+      [ [ 'hsl(0, 50, 50)', { saturation: -25 } ], 'hsl(0, 24.7, 50)' ],
+      [ [ 'hsl(0, 50, 50)', { lightness: -25 } ], 'hsl(0, 50, 25.1)' ],
+      [ [ 'hsl(300, 50, 50)', { hue: 100 } ], 'hsl(40, 49.8, 50)' ],
+      [ [ 'hsl(0, 50, 50)', { hue: -100 } ], 'hsl(260, 49.8, 50)' ],
+      [ [ 'hsl(0, 100, 50)', { saturation: 25 } ], 'hsl(0, 100, 50)' ],
+      [ [ 'hsl(0, 0, 50)', { saturation: -25 } ], 'hsl(0, 0, 50.2)' ],
+    ];
+
+    tests.forEach ( ( [ args, result ] ) => {
+      t.is ( HSL.output ( Color.parse ( adjust ( ...args ) ) ), result );
+    });
+
+  });
+
+  it ( 'adjusts alpha', t => {
+
+    const tests = [
+      [ [ 'rgba(0, 0, 0, 0)', { alpha: 0.5 } ], 'rgba(0, 0, 0, 0.5)' ],
+      [ [ 'hsla(0, 0, 0, 0)', { alpha: 0.5 } ], 'rgba(0, 0, 0, 0.5)' ],
+      [ [ 'rgba(0, 0, 0, 0)', { alpha: 1 } ], '#000000' ],
+      [ [ 'rgba(0, 0, 0, 1)', { alpha: -0.5 } ], 'rgba(0, 0, 0, 0.5)' ],
+      [ [ 'rgba(0, 0, 0, 1)', { alpha: -1 } ], 'rgba(0, 0, 0, 0)' ],
+      [ [ 'rgba(0, 0, 0, 0.5)', { alpha: 1 } ], '#000000' ],
+      [ [ 'rgba(0, 0, 0, 0.5)', { alpha: -1 } ], 'rgba(0, 0, 0, 0)' ],
+    ];
+
+    tests.forEach ( ( [ args, result ] ) => {
+      t.is ( adjust ( ...args ), result );
+    });
+
+  });
+
+  it ( 'throws an Error when adjusting RGB and HSL properties at the same time', t => {
+
+    const tests = [
+      [ '#000', { red: 0, hue: 0 } ],
+      [ '#000', { green: 0, lightness: 0 } ],
+      [ '#000', { blue: 0, saturation: 0 } ],
+    ];
+
+    tests.forEach ( ( args ) => {
+      t.throws ( () => adjust ( ...args ), 'Cannot adjust an RGB property at the same time as an HSL property' );
+    });
+
+  });
+
+  it ( 'throws an Error for out of range amounts', t => {
+
+    const tests = [
+      [ '#000', { red:  256 } ],
+      [ '#000', { red: -256 } ],
+      [ '#000', { green:  256 } ],
+      [ '#000', { green: -256 } ],
+      [ '#000', { blue:  256 } ],
+      [ '#000', { blue: -256 } ],
+      [ '#000', { lightness:  101 } ],
+      [ '#000', { lightness: -101 } ],
+      [ '#000', { saturation:  101 } ],
+      [ '#000', { saturation: -101 } ],
+      [ '#000', { alpha:  1.01 } ],
+      [ '#000', { alpha: -1.01 } ],
+    ];
+
+    tests.forEach ( ( args ) => {
+      t.throws ( () => adjust ( ...args ) );
+    });
+    
+  });
+
+});


### PR DESCRIPTION
This method serves to approximate Sass' [color.adjust](https://sass-lang.com/documentation/modules/color#adjust). I have made a few changes to the API. Namely, Sass allows you to adjust any channel (R/G/B/H/S/L/A) by specifying the appropriate argument. I figured the best way to do this in JS is to accept an `options` object. Users can then pass whichever properties they want to update. 

Also, my `adjust` only accepts amounts as numbers. So `adjust ( color, {  saturation: '10%' )` won't work, but `adjust ( color, {  saturation: 10 )` will. Units need to be inferred by channel.

This is by far some of the most involved code in the library. It is not complicated, there is just a lot to handle. I tried to keep it succinct  as possible while maintaining readability. If you have any suggestions for how it can be cleaned up please let me know. 