### PR TITLE
Add missing license to package.json as in license file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "khroma",
   "repository": "github:fabiospampinato/khroma",
   "description": "A collection of functions for manipulating CSS colors, inspired by SASS.",
+  "license": "MIT",
   "version": "2.0.0",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
Hey,
I found your NPM package as a dependency of mermaid. Your most recent version 2.0.0 is missing the license in NPM. This PR adds the missing license which would only require publishing after merging