### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "khroma",
   "repository": "github:fabiospampinato/khroma",
   "description": "A collection of functions for manipulating CSS colors, inspired by SASS.",
+  "license": "MIT",
   "version": "2.1.0",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
So that the license properly displays on npmjs.com and is detected by automated tooling